### PR TITLE
#43: More robust 'install_puppet_agent' for centos 6x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puppet Demonstration [![Build Status](https://travis-ci.org/jeff1evesque/puppet-demonstration.svg?branch=master)](https://travis-ci.org/jeff1evesque/puppet-demonstration)
 
-This repository is a simple demonstration of a virtualized environment
+This repository is a simple demonstration of virtualized environments
  ([vagrant](https://www.vagrantup.com/) + [virtualbox](https://www.virtualbox.org/)),
  tailored to exhibit the [puppetserver](https://docs.puppet.com/puppetserver/latest/services_master_puppetserver.html)
  / [puppetagent](https://docs.puppet.com/puppet/latest/reference/man/agent.html) ecosystem,

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repository is a simple demonstration of virtualized environments
  which vagrant provisions via the [`Vagrantfile`](https://github.com/jeff1evesque/puppet-demonstration/blob/master/Vagrantfile),
  using corresponding [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts).
  Though, it is recommended that Centos 7x is used for both the puppetserver,
- and additional puppetagents, the install scripts are flexible enough to allow
- puppetagent's to be contained within [Centos 6x](https://wiki.centos.org/Download)
+ and additional puppetagents, the [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts)
+ are flexible enough to allow puppetagent's to reside in [Centos 6x](https://wiki.centos.org/Download)
  operating systems.
 
  When vagrant completes provisioning, a puppetserver, with a corresponding

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ This repository is a simple demonstration of virtualized environments
  has been created from a [minimal iso](http://isoredirect.centos.org/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso),
  which vagrant provisions via the [`Vagrantfile`](https://github.com/jeff1evesque/puppet-demonstration/blob/master/Vagrantfile),
  using corresponding [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts).
- Though, it is recommended that Centos 7x is used for both the puppetserver,
- and additional puppetagents, the [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts)
- are flexible enough to allow puppetagent's to reside in [Centos 6x](https://wiki.centos.org/Download)
- operating systems.
 
- When vagrant completes provisioning, a puppetserver, with a corresponding
- [foreman](https://theforeman.org/) gui, is available on the host via the ip
- `192.168.0.10`, which can be used to manage various puppetagent nodes:
+Though, it is recommended to use Centos 7x for both the puppetserver, and
+ additional puppetagents, the [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts)
+ are flexible enough to allow puppetagent's to reside in [Centos 6x](https://wiki.centos.org/Download)
+ operating systems. Regardless of implementation, when vagrant completes
+ provisioning, a puppetserver, with a corresponding [foreman](https://theforeman.org/)
+ gui, is available on the host via the ip `192.168.0.10`, which can be used to manage various puppetagent nodes:
 
 ![Foreman Login](https://cloud.githubusercontent.com/assets/2907085/19436102/4c40ca40-943c-11e6-9554-cd13f363569c.PNG)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This repository is a simple demonstration of a virtualized environment
  has been created from a [minimal iso](http://isoredirect.centos.org/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso),
  which vagrant provisions via the [`Vagrantfile`](https://github.com/jeff1evesque/puppet-demonstration/blob/master/Vagrantfile),
  using corresponding [install scripts](https://github.com/jeff1evesque/puppet-demonstration/tree/master/install_scripts).
+ Though, it is recommended that Centos 7x is used for both the puppetserver,
+ and additional puppetagents, the install scripts are flexible enough to allow
+ puppetagent's to be contained within [Centos 6x](https://wiki.centos.org/Download)
+ operating systems.
 
  When vagrant completes provisioning, a puppetserver, with a corresponding
  [foreman](https://theforeman.org/) gui, is available on the host via the ip

--- a/install_scripts/install_puppet_agent
+++ b/install_scripts/install_puppet_agent
@@ -56,7 +56,7 @@ fi
 ## install puppetagent
 if [ "$OS_VERSION" -lt 7 ]; then
     rpm -e "$PUPPET_6_RPM"
-    rpm -ivh http://yum.puppetlabs.com/"$PUPPET_6_RPM".rpm
+    rpm -ivh https://yum.puppetlabs.com/"$PUPPET_6_RPM".rpm
 else
     rpm -e "$PUPPET_7_RPM"
     rpm -Uvh https://yum.puppetlabs.com/"$PUPPET_7_RPM".rpm
@@ -78,11 +78,15 @@ echo "$HOST_IP	$HOST_FQDN" >> /etc/hosts
 sudo /etc/init.d/network restart
 
 ## get hostname
-HOSTNAME=$(hostnamectl --static)
+if [ "$OS_VERSION" -lt 7 ]; then
+    HOSTNAME=$(hostname)
+else
+    HOSTNAME=$(hostnamectl --static)
+fi
 
 ## assign puppet agent configuration
-sudo /opt/puppetlabs/bin/puppet config set server "$HOST_FQDN"
-sudo /opt/puppetlabs/bin/puppet config set certname "$HOSTNAME"
+sudo puppet config set server "$HOST_FQDN"
+sudo puppet config set certname "$HOSTNAME"
 
 ## reboot to apply above changes
 ##

--- a/install_scripts/install_puppet_agent
+++ b/install_scripts/install_puppet_agent
@@ -85,8 +85,8 @@ else
 fi
 
 ## assign puppet agent configuration
-sudo puppet config set server "$HOST_FQDN"
-sudo puppet config set certname "$HOSTNAME"
+puppet config set server "$HOST_FQDN"
+puppet config set certname "$HOSTNAME"
 
 ## reboot to apply above changes
 ##

--- a/install_scripts/install_puppet_agent
+++ b/install_scripts/install_puppet_agent
@@ -85,8 +85,8 @@ else
 fi
 
 ## assign puppet agent configuration
-puppet config set server "$HOST_FQDN"
-puppet config set certname "$HOSTNAME"
+/opt/puppetlabs/bin/puppet config set server "$HOST_FQDN"
+/opt/puppetlabs/bin/puppet config set certname "$HOSTNAME"
 
 ## reboot to apply above changes
 ##


### PR DESCRIPTION
Resolves #43.